### PR TITLE
Suggest using svn cp rather than cp -R

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In the example below, we are creating a new directory `1.0.2`, and copying all f
 
 ```
 
-cp -R /Users/Desktop/NameOfYourTheme/1.0.1 /Users/Desktop/NameOfYourTheme/1.0.2
+svn cp 1.0.1 1.0.2
 
 ```
 


### PR DESCRIPTION
using `cp -R` copies the files, but doesn't copy the history.

Using `svn cp` will take the history of the files along with it, so that the commit only shows the differences, rather than entire files being added.

`svn propset svn:ignore` could also be used to remove the need to ignore `.DS_Store`/`__MACOSX` items.